### PR TITLE
obl/oblas_lite: add OBLAS_TINY to disable look-up table

### DIFF
--- a/rs.c
+++ b/rs.c
@@ -75,7 +75,7 @@ static int invert_mat(u8 *src, u8 *wrk, u8 **dst, int V0, int K, int T, int *c, 
     return 0;
 }
 
-void reed_solomon_init()
+void reed_solomon_init(void)
 {
 }
 


### PR DESCRIPTION
I implemented your suggestion from https://github.com/sleepybishop/nanorq/pull/10#issuecomment-1048392099 and it works great!
This brings the size of `rs.o` down to just 2k on Cortex-M4 with recovery still being plenty fast for firmware updates where speed is measured in kilobytes / s anyway.

Doesn't look too bad on Linux either:

#### master

```
===BEGIN===P SEED: 1645650675 K: 20 N: 10 T: 64
data shards = 20, repair shards = 10, encoded 128 MB in 0.732 secs, throughput: 174.8MB/s
data shards = 20, repair shards = 10, decoded 128 MB in 0.493 secs, throughput: 259.8MB/s
total time: 3.772|0.732|0.493
```

#### OBLAS_TINY

```
===BEGIN===P SEED: 1645650714 K: 20 N: 10 T: 64
data shards = 20, repair shards = 10, encoded 128 MB in 1.541 secs, throughput: 83.1MB/s
data shards = 20, repair shards = 10, decoded 128 MB in 1.017 secs, throughput: 125.8MB/s
total time: 5.127|1.541|1.017
```