### PR TITLE
Allow case where parity shard count is greater than data shard count

### DIFF
--- a/rs.c
+++ b/rs.c
@@ -82,7 +82,7 @@ void reed_solomon_init(void)
 reed_solomon *reed_solomon_new(int ds, int ps)
 {
     reed_solomon *rs = NULL;
-    if ((ds + ps) > DATA_SHARDS_MAX || ds <= 0 || ps <= 0 || ps > ds)
+    if ((ds + ps) > DATA_SHARDS_MAX || ds <= 0 || ps <= 0)
         return NULL;
     rs = calloc(1, sizeof(reed_solomon) + 2 * ps * ds);
     if (!rs)

--- a/t/00util/bench.c
+++ b/t/00util/bench.c
@@ -18,9 +18,9 @@ double now(time_t epoch)
 }
 
 typedef reed_solomon rs_t;
-void cleanup(uint8_t **buf, uint8_t **cmp, uint8_t *marks, int K)
+void cleanup(uint8_t **buf, uint8_t **cmp, uint8_t *marks, int K, int N)
 {
-    for (int i = 0; i < 2 * K; i++) {
+    for (int i = 0; i < K + N; i++) {
         free(buf[i]);
         free(cmp[i]);
     }
@@ -31,12 +31,12 @@ void cleanup(uint8_t **buf, uint8_t **cmp, uint8_t *marks, int K)
 
 int run(int seed, int K, int N, int T, double *et, double *dt)
 {
-    uint8_t **buf = calloc(2 * K, T * sizeof(uint8_t *));
-    uint8_t **cmp = calloc(2 * K, T * sizeof(uint8_t *));
-    uint8_t *marks = calloc(1, 2 * K);
+    uint8_t **buf = calloc(K + N, T * sizeof(uint8_t *));
+    uint8_t **cmp = calloc(K + N, T * sizeof(uint8_t *));
+    uint8_t *marks = calloc(1, K + N);
     int ret = 0;
 
-    for (int i = 0; i < 2 * K; i++) {
+    for (int i = 0; i < K + N; i++) {
         buf[i] = calloc(1, T);
         cmp[i] = calloc(1, T);
     }
@@ -51,7 +51,7 @@ int run(int seed, int K, int N, int T, double *et, double *dt)
     reed_solomon_init();
     rs_t *rs = reed_solomon_new(K, N);
     if (!rs) {
-        cleanup(buf, cmp, marks, K);
+        cleanup(buf, cmp, marks, K, N);
         printf("failed to init codec\n");
         return -1;
     }
@@ -87,7 +87,7 @@ int run(int seed, int K, int N, int T, double *et, double *dt)
     }
     assert(failed == 0);
 
-    cleanup(buf, cmp, marks, K);
+    cleanup(buf, cmp, marks, K, N);
     return ret;
 }
 


### PR DESCRIPTION
I'm working on replacing the Reed-Solomon implementation in [Sunshine](https://github.com/LizardByte/Sunshine), an NVIDIA GameStream host, with nanors (with great performance results). For the most part it was a drop-in replacement, however there is one case which nanors doesn't currently support: `ps > ds`

There is a configurable attribute in the SDP used by GameStream that allows the client to specify a minimum parity shard count per frame. NVIDIA's official clients and Moonlight both set this to 2, which means we can sometimes encounter a case where we have a small frame with only 1 data shard that will be generating 2 parity shards, which fails the check here.

This check appears to be superfluous, so I've removed it and updated the tests and benchmark to exercise that case. The tests required a bit more work than would be otherwise necessarily since it had assumptions that `2 * K >= K + N` in various places that needed to be adjusted. I also updated them to ensure that a failure of `reed_solomon_new()` would result in a `FAILED` output, rather than just outputting nothing.

I locally ran `make check` and `make ubsan` to verify this change.