### PR TITLE
rs: repurpose reed_solomon_init() to initialize static buffer

### DIFF
--- a/rs.h
+++ b/rs.h
@@ -12,10 +12,11 @@ typedef struct _reed_solomon {
     uint8_t p[];
 } reed_solomon;
 
-//#define reed_solomon_init()
+#define reed_solomon_bufsize(ds, ps) (sizeof(reed_solomon) + 2 * (ps) * (ds))
 #define reed_solomon_reconstruct reed_solomon_decode
 
 void reed_solomon_init(void);
+reed_solomon *reed_solomon_new_static(void *buf, size_t len, int ds, int ps);
 reed_solomon *reed_solomon_new(int data_shards, int parity_shards);
 void reed_solomon_release(reed_solomon *rs);
 


### PR DESCRIPTION
nanors only uses the heap in `reed_solomon_new()` to allocate a context struct.
If we don't want to use the heap at all (only use static allocation) we can also provide that buffer and initialize it with the context.

The most natural name for this would be `reed_solomon_init()` but this function already exists - turns out it's a no-op.

So instead of coming up with a new function name, I decided to repurposed `reed_solomon_init()` for this. 