### PR TITLE
add msvc compiler support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Dependencies
         run: |
@@ -27,29 +27,22 @@ jobs:
         run: make valgrind
 
   ci-arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y qemu-user-static binfmt-support gcc-aarch64-linux-gnu libc6-dev-arm64-cross
-
-      - name: Tests (ARM64 Emulation)
+      - name: Tests (ARM64 Native)
         env:
-          QEMU_LD_PREFIX: /usr/aarch64-linux-gnu
           CPPFLAGS: -DOBLAS_NEON
-          CI_EMULATION: 1
         run: |
-          make CC=aarch64-linux-gnu-gcc CFLAGS="-O3 -g -std=c11 -Wall -I. -Ideps/obl -funroll-loops -ftree-vectorize" check
+          make check
 
   ci-riscv64:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Dependencies
         run: |
@@ -67,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Tests (AVX2)
         run: make check CPPFLAGS="-DOBLAS_AVX2" CFLAGS="-O3 -g -std=c11 -Wall -I. -Ideps/obl -mavx2"
@@ -76,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download Intel SDE
         run: |
@@ -86,3 +79,22 @@ jobs:
 
       - name: Tests (AVX-512 Emulation)
         run: make RUN="sde64 -skx --" check CPPFLAGS="-DOBLAS_AVX512" CFLAGS="-O3 -g -std=c11 -Wall -I. -Ideps/obl -mavx512f -mavx512bw"
+
+  ci-windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up MSVC Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Compile (MSVC)
+        run: |
+          cl /c /O2 /W3 /I. /Ideps/obl rs.c rs16.c rs16_afft.c deps/obl/oblas_common.c deps/obl/oblas_lite.c deps/obl/oblas16.c deps/obl/oblas16_afft.c
+          cl t/00util/test.c rs.obj rs16.obj rs16_afft.obj oblas_common.obj oblas_lite.obj oblas16.obj oblas16_afft.obj /Fe:test.exe /I. /Ideps/obl
+          cl t/00util/test16.c rs.obj rs16.obj rs16_afft.obj oblas_common.obj oblas_lite.obj oblas16.obj oblas16_afft.obj /Fe:test16.exe /I. /Ideps/obl
+          cl t/00util/test16_afft.c rs.obj rs16.obj rs16_afft.obj oblas_common.obj oblas_lite.obj oblas16.obj oblas16_afft.obj /Fe:test16_afft.exe /I. /Ideps/obl
+          .\test.exe
+          .\test16.exe
+          .\test16_afft.exe

--- a/deps/obl/oblas16.c
+++ b/deps/obl/oblas16.c
@@ -272,6 +272,7 @@ OBLAS16_GENERATE_IMPL_X2(ssse3, __attribute__((target("ssse3"))), __m128i, _mm_l
 OBLAS16_GENERATE_IMPL_X2(ssse3_gfni, __attribute__((target("ssse3,gfni"))), __m128i, _mm_loadu_si128, _mm_storeu_si128,
                          _mm_xor_si128, VEC_MUL_INIT_ssse3_gfni, VEC_MUL_CORE_ssse3_gfni)
 
+#if !defined(_MSC_VER) || defined(__AVX2__)
 /* AVX2 */
 #define VEC_MUL_INIT_avx2()                                                                                                        \
     uint8_t t0l[16], t1l[16], t2l[16], t3l[16];                                                                                    \
@@ -330,6 +331,8 @@ OBLAS16_GENERATE_IMPL_X2(avx2, __attribute__((target("avx2"))), __m256i, _mm256_
 OBLAS16_GENERATE_IMPL_X2(avx2_gfni, __attribute__((target("avx2,gfni"))), __m256i, _mm256_loadu_si256, _mm256_storeu_si256,
                          _mm256_xor_si256, VEC_MUL_INIT_avx2_gfni, VEC_MUL_CORE_avx2_gfni)
 
+#endif
+#if !defined(_MSC_VER) || defined(__AVX512F__)
 /* AVX512 */
 #define VEC_MUL_INIT_avx512()                                                                                                      \
     uint8_t t0l[16], t1l[16], t2l[16], t3l[16];                                                                                    \
@@ -389,6 +392,7 @@ OBLAS16_GENERATE_IMPL_X2(avx512_gfni, __attribute__((target("avx512f,avx512bw,av
                          _mm512_loadu_si512, _mm512_storeu_si512, _mm512_xor_si512, VEC_MUL_INIT_avx512_gfni,
                          VEC_MUL_CORE_avx512_gfni)
 
+#endif
 #endif // OBLAS_ARCH_X86
 
 #if defined(OBLAS_ARCH_ARM) && defined(__ARM_NEON)
@@ -563,6 +567,7 @@ void oblas16_get_impl(struct oblas16_impl *impl)
     impl->align_size = sizeof(void *);
 
 #if defined(OBLAS_ARCH_X86)
+#if !defined(_MSC_VER) || defined(__AVX512F__)
     if (__builtin_cpu_supports("avx512f") && __builtin_cpu_supports("gfni")) {
         impl->axpy = oblas16_axpy_avx512_gfni;
         impl->scal = oblas16_scal_avx512_gfni;
@@ -573,7 +578,10 @@ void oblas16_get_impl(struct oblas16_impl *impl)
         impl->scal = oblas16_scal_avx512;
         impl->axiy = oblas16_axiy_avx512;
         impl->align_size = 64;
-    } else if (__builtin_cpu_supports("avx2") && __builtin_cpu_supports("gfni")) {
+    } else
+#endif
+#if !defined(_MSC_VER) || defined(__AVX2__)
+        if (__builtin_cpu_supports("avx2") && __builtin_cpu_supports("gfni")) {
         impl->axpy = oblas16_axpy_avx2_gfni;
         impl->scal = oblas16_scal_avx2_gfni;
         impl->axiy = oblas16_axiy_avx2_gfni;
@@ -583,7 +591,9 @@ void oblas16_get_impl(struct oblas16_impl *impl)
         impl->scal = oblas16_scal_avx2;
         impl->axiy = oblas16_axiy_avx2;
         impl->align_size = 32;
-    } else if (__builtin_cpu_supports("ssse3") && __builtin_cpu_supports("gfni")) {
+    } else
+#endif
+        if (__builtin_cpu_supports("ssse3") && __builtin_cpu_supports("gfni")) {
         impl->axpy = oblas16_axpy_ssse3_gfni;
         impl->scal = oblas16_scal_ssse3_gfni;
         impl->axiy = oblas16_axiy_ssse3_gfni;
@@ -615,6 +625,7 @@ void oblas16_get_impl_by_name(struct oblas16_impl *impl, const char *name)
     impl->align_size = sizeof(void *);
 
 #if defined(OBLAS_ARCH_X86)
+#if !defined(_MSC_VER) || defined(__AVX512F__)
     if (strcmp(name, "avx512_gfni") == 0) {
         impl->axpy = oblas16_axpy_avx512_gfni;
         impl->scal = oblas16_scal_avx512_gfni;
@@ -625,7 +636,10 @@ void oblas16_get_impl_by_name(struct oblas16_impl *impl, const char *name)
         impl->scal = oblas16_scal_avx512;
         impl->axiy = oblas16_axiy_avx512;
         impl->align_size = 64;
-    } else if (strcmp(name, "avx2_gfni") == 0) {
+    } else
+#endif
+#if !defined(_MSC_VER) || defined(__AVX2__)
+        if (strcmp(name, "avx2_gfni") == 0) {
         impl->axpy = oblas16_axpy_avx2_gfni;
         impl->scal = oblas16_scal_avx2_gfni;
         impl->axiy = oblas16_axiy_avx2_gfni;
@@ -635,7 +649,9 @@ void oblas16_get_impl_by_name(struct oblas16_impl *impl, const char *name)
         impl->scal = oblas16_scal_avx2;
         impl->axiy = oblas16_axiy_avx2;
         impl->align_size = 32;
-    } else if (strcmp(name, "ssse3_gfni") == 0) {
+    } else
+#endif
+        if (strcmp(name, "ssse3_gfni") == 0) {
         impl->axpy = oblas16_axpy_ssse3_gfni;
         impl->scal = oblas16_scal_ssse3_gfni;
         impl->axiy = oblas16_axiy_ssse3_gfni;

--- a/deps/obl/oblas16_afft.c
+++ b/deps/obl/oblas16_afft.c
@@ -228,6 +228,7 @@ OBLAS16_AFFT_GENERATE_IMPL_X2(ssse3, __attribute__((target("ssse3"))), __m128i, 
 OBLAS16_AFFT_GENERATE_IMPL_X2(ssse3_gfni, __attribute__((target("ssse3,gfni"))), __m128i, _mm_loadu_si128, _mm_storeu_si128,
                               _mm_xor_si128, VEC_MUL_INIT_ssse3_gfni, VEC_MUL_CORE_ssse3_gfni)
 
+#if !defined(_MSC_VER) || defined(__AVX2__)
 /* AVX2 */
 #define VEC_MUL_INIT_avx2()                                                                                                        \
     __m256i T0_lo = _mm256_broadcastsi128_si256(_mm_loadu_si128((__m128i *)std_twiddles[twist][0]));                               \
@@ -281,6 +282,8 @@ OBLAS16_AFFT_GENERATE_IMPL_X2(avx2, __attribute__((target("avx2"))), __m256i, _m
 OBLAS16_AFFT_GENERATE_IMPL_X2(avx2_gfni, __attribute__((target("avx2,gfni"))), __m256i, _mm256_loadu_si256, _mm256_storeu_si256,
                               _mm256_xor_si256, VEC_MUL_INIT_avx2_gfni, VEC_MUL_CORE_avx2_gfni)
 
+#endif
+#if !defined(_MSC_VER) || defined(__AVX512F__)
 /* AVX512 */
 #define VEC_MUL_INIT_avx512()                                                                                                      \
     __m512i T0_lo = _mm512_broadcast_i32x4(_mm_loadu_si128((__m128i *)std_twiddles[twist][0]));                                    \
@@ -335,6 +338,7 @@ OBLAS16_AFFT_GENERATE_IMPL_X2(avx512_gfni, __attribute__((target("avx512f,avx512
                               _mm512_loadu_si512, _mm512_storeu_si512, _mm512_xor_si512, VEC_MUL_INIT_avx512_gfni,
                               VEC_MUL_CORE_avx512_gfni)
 
+#endif
 #endif /* OBLAS_ARCH_X86 */
 
 #if defined(OBLAS_ARCH_ARM) && defined(__ARM_NEON)
@@ -516,6 +520,7 @@ void oblas16_afft_get_impl(struct oblas16_afft_impl *impl)
     impl->align_size = sizeof(void *);
 
 #if defined(OBLAS_ARCH_X86)
+#if !defined(_MSC_VER) || defined(__AVX512F__)
     if (__builtin_cpu_supports("avx512f") && __builtin_cpu_supports("gfni")) {
         impl->bfly_fwd = oblas16_afft_bfly_fwd_avx512_gfni;
         impl->bfly_inv = oblas16_afft_bfly_inv_avx512_gfni;
@@ -524,7 +529,10 @@ void oblas16_afft_get_impl(struct oblas16_afft_impl *impl)
         impl->bfly_fwd = oblas16_afft_bfly_fwd_avx512;
         impl->bfly_inv = oblas16_afft_bfly_inv_avx512;
         impl->align_size = 64;
-    } else if (__builtin_cpu_supports("avx2") && __builtin_cpu_supports("gfni")) {
+    } else
+#endif
+#if !defined(_MSC_VER) || defined(__AVX2__)
+        if (__builtin_cpu_supports("avx2") && __builtin_cpu_supports("gfni")) {
         impl->bfly_fwd = oblas16_afft_bfly_fwd_avx2_gfni;
         impl->bfly_inv = oblas16_afft_bfly_inv_avx2_gfni;
         impl->align_size = 32;
@@ -532,7 +540,9 @@ void oblas16_afft_get_impl(struct oblas16_afft_impl *impl)
         impl->bfly_fwd = oblas16_afft_bfly_fwd_avx2;
         impl->bfly_inv = oblas16_afft_bfly_inv_avx2;
         impl->align_size = 32;
-    } else if (__builtin_cpu_supports("ssse3") && __builtin_cpu_supports("gfni")) {
+    } else
+#endif
+        if (__builtin_cpu_supports("ssse3") && __builtin_cpu_supports("gfni")) {
         impl->bfly_fwd = oblas16_afft_bfly_fwd_ssse3_gfni;
         impl->bfly_inv = oblas16_afft_bfly_inv_ssse3_gfni;
         impl->align_size = 16;
@@ -743,7 +753,9 @@ uint16_t oblas16_afft_compute_gamma(int c, int log_M, int log_K_prime, int log_N
         return (c == c_out) ? 1 : 0;
     int log_macro_ifft = log_K_prime - log_M;
     int log_macro_fft = log_N - log_M;
-    uint16_t arr[32768] = {0};
+    uint16_t *arr = (uint16_t *)obl_alloc(1, 32768 * sizeof(uint16_t), 64);
+    if (!arr)
+        return 0;
     arr[c] = 1;
     for (int k_macro = 0; k_macro < log_macro_ifft; k_macro++) {
         int k = k_macro + log_M;
@@ -763,5 +775,7 @@ uint16_t oblas16_afft_compute_gamma(int c, int log_M, int log_K_prime, int log_N
             gamma_process_block(arr, half, b * step, fft_twiddles[k][b], 1);
         }
     }
-    return arr[c_out];
+    uint16_t ret = arr[c_out];
+    obl_free(arr);
+    return ret;
 }

--- a/deps/obl/oblas_common.c
+++ b/deps/obl/oblas_common.c
@@ -2,6 +2,9 @@
 #include "oblas_common.h"
 #include <stdlib.h>
 #include <string.h>
+#if defined(_MSC_VER) || defined(__MINGW32__)
+#include <malloc.h>
+#endif
 
 void obl_swap(uint8_t *a, uint8_t *b, unsigned k)
 {

--- a/deps/obl/oblas_common.h
+++ b/deps/obl/oblas_common.h
@@ -12,6 +12,71 @@
 #define OBLAS_ARCH_RISCV 1
 #endif
 
+#if defined(_MSC_VER) && !defined(__clang__)
+#include <intrin.h>
+#include <stdlib.h>
+#include <string.h>
+#include <malloc.h>
+
+#define __builtin_bswap64 _byteswap_uint64
+#define __builtin_bswap32 _byteswap_ulong
+#define __attribute__(x)
+#define restrict __restrict
+
+static inline int __builtin_popcount(unsigned int x)
+{
+#if defined(_M_X64) || defined(_M_IX86)
+    return (int)__popcnt(x);
+#else
+    /* Portable SW fallback */
+    x = x - ((x >> 1) & 0x55555555);
+    x = (x & 0x33333333) + ((x >> 2) & 0x33333333);
+    return (((x + (x >> 4)) & 0x0F0F0F0F) * 0x01010101) >> 24;
+#endif
+}
+
+static inline int __builtin_ctz(unsigned int x)
+{
+    unsigned long index;
+    if (_BitScanForward(&index, x)) {
+        return (int)index;
+    }
+    return 32;
+}
+
+#if defined(OBLAS_ARCH_X86)
+static inline int __builtin_cpu_supports(const char *feature)
+{
+    int cpuInfo[4] = {0};
+    __cpuid(cpuInfo, 0);
+    int max_leaf = cpuInfo[0];
+
+    if (strcmp(feature, "ssse3") == 0) {
+        if (max_leaf >= 1) {
+            __cpuid(cpuInfo, 1);
+            return (cpuInfo[2] & (1 << 9)) != 0;
+        }
+    } else if (strcmp(feature, "avx2") == 0) {
+        if (max_leaf >= 7) {
+            __cpuidex(cpuInfo, 7, 0);
+            return (cpuInfo[1] & (1 << 5)) != 0;
+        }
+    } else if (strcmp(feature, "avx512f") == 0) {
+        if (max_leaf >= 7) {
+            __cpuidex(cpuInfo, 7, 0);
+            return (cpuInfo[1] & (1 << 16)) != 0;
+        }
+    } else if (strcmp(feature, "gfni") == 0) {
+        if (max_leaf >= 7) {
+            __cpuidex(cpuInfo, 7, 0);
+            return (cpuInfo[2] & (1 << 8)) != 0;
+        }
+    }
+    return 0;
+}
+#endif /* OBLAS_ARCH_X86 */
+#endif /* defined(_MSC_VER) && !defined(__clang__) */
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/deps/obl/oblas_lite.c
+++ b/deps/obl/oblas_lite.c
@@ -133,6 +133,7 @@ static void obl_axpyb32_ref(u8 *a, u32 *b, u8 u, unsigned k)
 
 #if defined(OBLAS_ARCH_X86)
 
+#if !defined(_MSC_VER) || defined(__AVX512F__)
 /* avx512 gfni */
 #define VEC_INIT_avx512_gfni() const __m512i u_mat = _mm512_set1_epi64(GF2_8_AFFINE_MAT[u])
 #define VEC_CORE_avx512_gfni(bx, res) __m512i res = _mm512_gf2p8affine_epi64_epi8(bx, u_mat, 0)
@@ -154,7 +155,9 @@ GENERATE_IMPL(avx512_gfni, __attribute__((target("avx512f,avx512bw,avx512dq,avx5
     __m512i res = _mm512_xor_si512(lo_##res, hi_##res)
 GENERATE_IMPL(avx512_std, __attribute__((target("avx512f,avx512bw,avx512dq,avx512vl"))), __m512i, _mm512_loadu_si512,
               _mm512_storeu_si512, VEC_INIT_avx512_std, VEC_CORE_avx512_std, _mm512_xor_si512)
+#endif
 
+#if !defined(_MSC_VER) || defined(__AVX2__)
 /* avx2 gnfi */
 #define VEC_INIT_avx2_gfni() const __m256i u_mat = _mm256_set1_epi64x(GF2_8_AFFINE_MAT[u])
 #define VEC_CORE_avx2_gfni(bx, res) __m256i res = _mm256_gf2p8affine_epi64_epi8(bx, u_mat, 0)
@@ -176,6 +179,7 @@ GENERATE_IMPL(avx2_gfni, __attribute__((target("avx2,gfni"))), __m256i, _mm256_l
     __m256i res = _mm256_xor_si256(lo_##res, hi_##res)
 GENERATE_IMPL(avx2_std, __attribute__((target("avx2"))), __m256i, _mm256_loadu_si256, _mm256_storeu_si256, VEC_INIT_avx2_std,
               VEC_CORE_avx2_std, _mm256_xor_si256)
+#endif
 
 /* sse3 gfni */
 #define VEC_INIT_ssse3_gfni() const __m128i u_mat = _mm_set1_epi64x(GF2_8_AFFINE_MAT[u])
@@ -199,6 +203,7 @@ GENERATE_IMPL(ssse3_gfni, __attribute__((target("ssse3,gfni"))), __m128i, _mm_lo
 GENERATE_IMPL(ssse3_std, __attribute__((target("ssse3"))), __m128i, _mm_loadu_si128, _mm_storeu_si128, VEC_INIT_ssse3_std,
               VEC_CORE_ssse3_std, _mm_xor_si128)
 
+#if !defined(_MSC_VER) || defined(__AVX512F__)
 __attribute__((target("avx512f,avx512bw,avx512dq,avx512vl"))) static void obl_axpyb32_avx512(u8 *a, u32 *b, u8 u, unsigned k)
 {
     __m512i *ap = (__m512i *)a;
@@ -222,7 +227,9 @@ __attribute__((target("avx512f,avx512bw,avx512dq,avx512vl"))) static void obl_ax
     }
     obl_axpyb32_ref((u8 *)ap, b + p, u, k & 63);
 }
+#endif
 
+#if !defined(_MSC_VER) || defined(__AVX2__)
 __attribute__((target("avx2"))) static void obl_axpyb32_avx2(u8 *a, u32 *b, u8 u, unsigned k)
 {
     __m256i *ap = (__m256i *)a;
@@ -242,6 +249,7 @@ __attribute__((target("avx2"))) static void obl_axpyb32_avx2(u8 *a, u32 *b, u8 u
     }
     obl_axpyb32_ref((u8 *)ap, b + p, u, k & 31);
 }
+#endif
 
 __attribute__((target("ssse3"))) static void obl_axpyb32_ssse3(u8 *a, u32 *b, u8 u, unsigned k)
 {
@@ -409,6 +417,7 @@ void oblas_get_impl(struct oblas_impl *impl)
     impl->align_size = sizeof(void *);
 
 #if defined(OBLAS_ARCH_X86)
+#if !defined(_MSC_VER) || defined(__AVX512F__)
     if (__builtin_cpu_supports("avx512f") && __builtin_cpu_supports("gfni")) {
         impl->axpy = obl_axpy_avx512_gfni;
         impl->scal = obl_scal_avx512_gfni;
@@ -421,7 +430,10 @@ void oblas_get_impl(struct oblas_impl *impl)
         impl->axiy = obl_axiy_avx512_std;
         impl->axpyb32 = obl_axpyb32_avx512;
         impl->align_size = 64;
-    } else if (__builtin_cpu_supports("avx2") && __builtin_cpu_supports("gfni")) {
+    } else
+#endif
+#if !defined(_MSC_VER) || defined(__AVX2__)
+        if (__builtin_cpu_supports("avx2") && __builtin_cpu_supports("gfni")) {
         impl->axpy = obl_axpy_avx2_gfni;
         impl->scal = obl_scal_avx2_gfni;
         impl->axiy = obl_axiy_avx2_gfni;
@@ -433,7 +445,9 @@ void oblas_get_impl(struct oblas_impl *impl)
         impl->axiy = obl_axiy_avx2_std;
         impl->axpyb32 = obl_axpyb32_avx2;
         impl->align_size = 32;
-    } else if (__builtin_cpu_supports("ssse3") && __builtin_cpu_supports("gfni")) {
+    } else
+#endif
+        if (__builtin_cpu_supports("ssse3") && __builtin_cpu_supports("gfni")) {
         impl->axpy = obl_axpy_ssse3_gfni;
         impl->scal = obl_scal_ssse3_gfni;
         impl->axiy = obl_axiy_ssse3_gfni;

--- a/rs.c
+++ b/rs.c
@@ -189,8 +189,8 @@ int reed_solomon_decode(reed_solomon *rs, u8 **data, u8 *marks, int nr_shards, i
         return -1;
 
     u8 *wrk = rs->p + 1 * rs->ps * rs->ds;
-    u8 erasures[rs->ds], colperm[rs->ds];
-    u8 gaps = 0, rowperm[rs->ds];
+    u8 erasures[DATA_SHARDS_MAX], colperm[DATA_SHARDS_MAX];
+    u8 gaps = 0, rowperm[DATA_SHARDS_MAX];
 
     for (int i = 0; i < rs->ds; i++)
         if (marks[i])

--- a/rs.h
+++ b/rs.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include "oblas_common.h"
 
 #define DATA_SHARDS_MAX 255
 

--- a/rs16.h
+++ b/rs16.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include "oblas_common.h"
 
 #define DATA_SHARDS_MAX 65535
 

--- a/rs16_afft.c
+++ b/rs16_afft.c
@@ -114,6 +114,8 @@ struct afft_workspace {
     uint8_t *is_erased;
     uint32_t *error_locations;
     uint16_t *buf;
+    int *erasures;
+    int *E;
     void *flat_alloc;
     void (*axpy)(uint16_t *a, const uint16_t *b, uint16_t u, unsigned k);
     void (*axiy)(uint16_t *dst, const uint16_t *src, uint16_t twist, unsigned batch);
@@ -159,6 +161,8 @@ reed_solomon16_afft *reed_solomon16_afft_new(int data_shards, int parity_shards)
     size_t sz_is_erased = N * sizeof(uint8_t);
     size_t sz_error_locations = 65536 * sizeof(uint32_t);
     size_t sz_buf = N * BATCH_SIZE * sizeof(uint16_t);
+    size_t sz_erasures = 65536 * sizeof(int);
+    size_t sz_E = 65536 * sizeof(int);
 
     sz_chunk_buf = (sz_chunk_buf + 63) & ~63;
     sz_needed_buf = (sz_needed_buf + 63) & ~63;
@@ -169,9 +173,11 @@ reed_solomon16_afft *reed_solomon16_afft_new(int data_shards, int parity_shards)
     sz_is_erased = (sz_is_erased + 63) & ~63;
     sz_error_locations = (sz_error_locations + 63) & ~63;
     sz_buf = (sz_buf + 63) & ~63;
+    sz_erasures = (sz_erasures + 63) & ~63;
+    sz_E = (sz_E + 63) & ~63;
 
     size_t total_size = sz_chunk_buf + sz_needed_buf + sz_acc + sz_tmp_buf + sz_L_eval + sz_inv_Lp_eval + sz_is_erased +
-                        sz_error_locations + sz_buf;
+                        sz_error_locations + sz_buf + sz_erasures + sz_E;
 
     ws->flat_alloc = obl_alloc(1, total_size, 64);
     if (!ws->flat_alloc) {
@@ -198,6 +204,10 @@ reed_solomon16_afft *reed_solomon16_afft_new(int data_shards, int parity_shards)
     ws->error_locations = (uint32_t *)ptr;
     ptr += sz_error_locations;
     ws->buf = (uint16_t *)ptr;
+    ptr += sz_buf;
+    ws->erasures = (int *)ptr;
+    ptr += sz_erasures;
+    ws->E = (int *)ptr;
 
     oblas16_get_impl(&ws->o16);
     oblas16_afft_get_impl(&ws->afft);
@@ -262,7 +272,7 @@ int reed_solomon16_afft_encode(reed_solomon16_afft *rs, uint16_t **shards, int n
         uint16_t *acc = ws->acc;
         uint16_t *tmp_buf = ws->tmp_buf;
 
-        uint16_t *gamma_arr = (uint16_t *)obl_alloc(K / M + 1, sizeof(uint16_t), 1);
+        uint16_t *gamma_arr = (uint16_t *)calloc(K / M + 1, sizeof(uint16_t));
         for (int c = 0; c * M < K; c++) {
             gamma_arr[c] = oblas16_afft_compute_gamma(c, log_M, log_K_prime, log_N, K_prime / M);
         }
@@ -300,7 +310,7 @@ int reed_solomon16_afft_encode(reed_solomon16_afft *rs, uint16_t **shards, int n
                 memcpy(&shards[K + i][start], &acc[i * BATCH_SIZE], current_chunk * sizeof(uint16_t));
             }
         }
-        obl_free(gamma_arr);
+        free(gamma_arr);
     } else {
         /* original encoder for low rate / small n */
         for (int i = 0; i < P; i++) {
@@ -348,7 +358,7 @@ int reed_solomon16_afft_decode(reed_solomon16_afft *rs, uint16_t **shards, uint8
     int log_N = log2_int(N);
 
     /* find erasures */
-    int erasures[65535];
+    int *erasures = ws->erasures;
     int num_erasures = 0;
     for (int i = 0; i < K; i++) {
         if (marks[i])
@@ -367,7 +377,7 @@ int reed_solomon16_afft_decode(reed_solomon16_afft *rs, uint16_t **shards, uint8
         return -1; /* not enough shards */
 
     /* determine the complete set of evaluation points e that are considered erased. */
-    int E[65535];
+    int *E = ws->E;
     int num_E = 0;
 
     /* add missing data points */

--- a/t/00util/bench.c
+++ b/t/00util/bench.c
@@ -7,7 +7,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include "rs.h"
 #include "oblas_lite.h"

--- a/t/00util/bench16.c
+++ b/t/00util/bench16.c
@@ -7,7 +7,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include "rs16.h"
 

--- a/t/00util/bench16_afft.c
+++ b/t/00util/bench16_afft.c
@@ -7,7 +7,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include "rs16.h"
 #include "rs16_afft.h"

--- a/t/00util/test.c
+++ b/t/00util/test.c
@@ -7,7 +7,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include "rs.h"
 #include "oblas_lite.h"
@@ -449,7 +451,11 @@ int main(int argc, char *argv[])
 
     // Execute random tests for broader coverage
     printf("[RANDOM SEARCH] Running randomized codec iterations...\n");
-    for (int i = 0; i < 200; i++) {
+    int num_iterations = 200;
+    if (getenv("CI_EMULATION")) {
+        num_iterations = 20;
+    }
+    for (int i = 0; i < num_iterations; i++) {
         int K = MAP(rand(), RAND_MAX, 1, 50);
         int N = MAP(rand(), RAND_MAX, 1, 20);
         if ((K + N) > 255) {

--- a/t/00util/test16.c
+++ b/t/00util/test16.c
@@ -7,7 +7,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include "rs16.h"
 
@@ -251,7 +253,11 @@ int main(int argc, char *argv[])
     run_mds_property_tests();
 
     printf("[RANDOM SEARCH] Running randomized codec iterations...\n");
-    for (int i = 0; i < 200; i++) {
+    int num_iterations = 200;
+    if (getenv("CI_EMULATION")) {
+        num_iterations = 20;
+    }
+    for (int i = 0; i < num_iterations; i++) {
         int K = MAP(rand(), RAND_MAX, 1, 50);
         int N = MAP(rand(), RAND_MAX, 1, 20);
         if ((K + N) > 255)

--- a/t/00util/test16_afft.c
+++ b/t/00util/test16_afft.c
@@ -7,7 +7,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include "rs16.h"
 #include "rs16_afft.h"
@@ -245,7 +247,11 @@ int main(int argc, char *argv[])
     run_mds_property_tests();
 
     printf("[RANDOM SEARCH] Running randomized codec iterations...\n");
-    for (int i = 0; i < 200; i++) {
+    int num_iterations = 200;
+    if (getenv("CI_EMULATION")) {
+        num_iterations = 20;
+    }
+    for (int i = 0; i < num_iterations; i++) {
         int K = MAP(rand(), RAND_MAX, 1, 50);
         int N = MAP(rand(), RAND_MAX, 1, 20);
         if ((K + N) > 255)
@@ -264,7 +270,11 @@ int main(int argc, char *argv[])
     printf("[LARGE K] Running tests for big K...\n");
     int big_ks[] = {500, 1000, 2000, 5000, 10000};
     int losses[] = {5, 10};
-    for (int i = 0; i < sizeof(big_ks) / sizeof(big_ks[0]); i++) {
+    int num_big_ks = sizeof(big_ks) / sizeof(big_ks[0]);
+    if (getenv("CI_EMULATION")) {
+        num_big_ks = 2; /* Only test up to K=1000 under emulation */
+    }
+    for (int i = 0; i < num_big_ks; i++) {
         for (int j = 0; j < sizeof(losses) / sizeof(losses[0]); j++) {
             int K = big_ks[i];
             int N = (K * losses[j]) / 100;


### PR DESCRIPTION
This PR adds MSVC support by adding shims for GCC/Clang builtins in oblas_common.h and setting up a Windows CI job.